### PR TITLE
urls.py에 smarturls 적용

### DIFF
--- a/lawmakernews/urls.py
+++ b/lawmakernews/urls.py
@@ -17,27 +17,28 @@ Including another URLconf
 """
 from django.conf.urls import include, patterns, url
 from django.contrib import admin
+from smarturls import surl
 
 lawmaekers_urls = patterns(
     'lawmakers.views',
 
-    url(r'^$', 'lawmakers', name='lawmakers'),
-    url(r'^parties/$', 'parties', name='parties'),
+    surl('/', 'lawmakers', name='lawmakers'),
+    surl('parties/', 'parties', name='parties'),
     
-    url(r'^test_crawl_lawmakers/$', 'test_crawl_lawmakers', name='test_crawl_lawmakers'),
+    surl('test_crawl_lawmakers/', 'test_crawl_lawmakers', name='test_crawl_lawmakers'),
 )
 
 articles_urls = patterns(
     'articles.views',
 
-    url(r'^$', 'articles', name='articles'),
+    surl('/', 'articles', name='articles'),
     
-    url(r'^test_crawl_articles/$', 'test_crawl_articles', name='test_crawl_articles'),
+    surl('test_crawl_articles/', 'test_crawl_articles', name='test_crawl_articles'),
 )
 
 urlpatterns = [
-    url(r'^admin/', include(admin.site.urls)),
-    url(r'^lawmakers/', include(lawmaekers_urls, namespace='lawmakers')),
-    url(r'^articles/', include(articles_urls, namespace='articles')),
-    url(r'^$', 'articles.views.index', name='index'),
+    surl('admin/', include(admin.site.urls)),
+    surl('lawmakers/', include(lawmaekers_urls, namespace='lawmakers')),
+    surl('articles/', include(articles_urls, namespace='articles')),
+    surl('/', 'articles.views.index', name='index'),
 ]

--- a/pip_dependency.txt
+++ b/pip_dependency.txt
@@ -3,10 +3,13 @@ anyjson==0.3.3
 beautifulsoup4==4.3.2
 billiard==3.3.0.20
 celery==3.1.18
+colorlog==2.6.0
 Django==1.8.1
+django-debug-toolbar==1.3.2
 kombu==3.0.26
 psycopg2==2.6
 pytz==2015.4
 redis==2.10.3
 requests==2.7.0
-colorlog==2.6.0
+smarturls==0.1.4
+sqlparse==0.1.15


### PR DESCRIPTION
기존 django urls는 정규식 기반이라서 복잡함
smarturls는 flask에서 쓰는 직관적인 urls 표기법을 장고에 적용 가능하게 해줌
